### PR TITLE
Use environment variable for api url

### DIFF
--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
 
 export const api = axios.create({
-  baseURL: 'http://localhost:3333/',
-})
+  baseURL: import.meta.env.VITE_API_URL,
+});


### PR DESCRIPTION
Instância do Axios modificada para usar a URL vinda do arquivo .env.local como baseURL